### PR TITLE
Implement COPD analyzer module with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # Prueba01
-aplicación para uso médico: analizar los datos del paciente aportados por el médico y primero definir si llena criterios para el diagnóstico de EPOC Enfermedad Pulmonar Obstructiva Crónica y segundo clasificarla. Debe usar los datos aportados por la "Guía de la iniciativa GOLD 2025.pdf" 
+
+Aplicación para uso médico: analizar los datos del paciente aportados por el médico y definir si llena criterios para el diagnóstico de EPOC (Enfermedad Pulmonar Obstructiva Crónica) y clasificarla. Debe usar los datos aportados por la "Guía de la iniciativa GOLD 2025.pdf".
+
+## Uso del módulo `copd_analyzer`
+
+La lógica principal se encuentra en `src/copd_analyzer.py`. Para invocar el módulo desde otra parte de la aplicación:
+
+```python
+from src.copd_analyzer import diagnose
+
+paciente = {
+    "fev1_fvc": 0.65,
+    "fev1_percent_predicted": 85,
+    "symptom_score": 1,
+    "exacerbations_last_year": 0,
+    "hospitalizations_last_year": 0,
+}
+
+resultado = diagnose(paciente)
+print(resultado)
+# {'diagnosis': True, 'gold_stage': 1, 'risk_group': 'A'}
+```
+
+## Pruebas
+
+Las pruebas unitarias se encuentran en `tests/` y usan `pytest`.
+Para ejecutarlas:
+
+```bash
+pytest
+```

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,10 @@
+"""COPD analysis utilities."""
+
+from .copd_analyzer import diagnose, gold_stage, risk_group, PatientData
+
+__all__ = [
+    "diagnose",
+    "gold_stage",
+    "risk_group",
+    "PatientData",
+]

--- a/src/copd_analyzer.py
+++ b/src/copd_analyzer.py
@@ -1,0 +1,87 @@
+"""COPD Analyzer module based on the GOLD 2025 report.
+
+This module provides utilities to diagnose Chronic Obstructive Pulmonary
+Disease (COPD) and classify confirmed cases according to GOLD 2025
+recommendations.
+
+Patient data should be provided as a dictionary with the following keys:
+    - fev1_fvc: ratio of FEV1/FVC post-bronchodilation (float)
+    - fev1_percent_predicted: FEV1 percent predicted (float)
+    - symptom_score: symptom burden score (mMRC or CAT equivalent)
+    - exacerbations_last_year: number of exacerbations in the last year (int)
+    - hospitalizations_last_year: number of COPD hospitalizations in the last year (int)
+
+Example:
+    >>> from src.copd_analyzer import diagnose
+    >>> patient = {
+    ...     'fev1_fvc': 0.62,
+    ...     'fev1_percent_predicted': 78,
+    ...     'symptom_score': 1,
+    ...     'exacerbations_last_year': 0,
+    ...     'hospitalizations_last_year': 0,
+    ... }
+    >>> diagnose(patient)
+    {'diagnosis': True, 'gold_stage': 1, 'risk_group': 'A'}
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Dict, Any
+
+
+@dataclass
+class PatientData:
+    fev1_fvc: float
+    fev1_percent_predicted: float
+    symptom_score: int
+    exacerbations_last_year: int
+    hospitalizations_last_year: int
+
+
+def diagnose(data: Dict[str, Any]) -> Dict[str, Optional[Any]]:
+    """Return COPD diagnosis and classification results.
+
+    Parameters
+    ----------
+    data : dict
+        Patient data as described in the module docstring.
+    """
+    patient = PatientData(**data)
+
+    diagnosis = patient.fev1_fvc < 0.7
+    stage = gold_stage(patient.fev1_percent_predicted) if diagnosis else None
+    group = (
+        risk_group(
+            patient.symptom_score,
+            patient.exacerbations_last_year,
+            patient.hospitalizations_last_year,
+        )
+        if diagnosis
+        else None
+    )
+    return {"diagnosis": diagnosis, "gold_stage": stage, "risk_group": group}
+
+
+def gold_stage(fev1_percent: float) -> int:
+    """Classify COPD GOLD stage based on FEV1 percent predicted."""
+    if fev1_percent >= 80:
+        return 1
+    if fev1_percent >= 50:
+        return 2
+    if fev1_percent >= 30:
+        return 3
+    return 4
+
+
+def risk_group(symptom_score: int, exacerbations: int, hospitalizations: int) -> str:
+    """Return GOLD risk group (A, B, C, D) based on symptoms and exacerbations."""
+
+    high_symptoms = symptom_score >= 2
+    high_risk = exacerbations >= 2 or hospitalizations >= 1
+
+    if not high_symptoms and not high_risk:
+        return "A"
+    if high_symptoms and not high_risk:
+        return "B"
+    if not high_symptoms and high_risk:
+        return "C"
+    return "D"

--- a/tests/test_copd_analyzer.py
+++ b/tests/test_copd_analyzer.py
@@ -1,0 +1,46 @@
+import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+from src.copd_analyzer import diagnose, gold_stage, risk_group
+
+
+def test_diagnosis_positive_stage1_group_a():
+    patient = {
+        "fev1_fvc": 0.65,
+        "fev1_percent_predicted": 85,
+        "symptom_score": 1,
+        "exacerbations_last_year": 0,
+        "hospitalizations_last_year": 0,
+    }
+    result = diagnose(patient)
+    assert result["diagnosis"] is True
+    assert result["gold_stage"] == 1
+    assert result["risk_group"] == "A"
+
+
+def test_diagnosis_positive_stage3_group_d():
+    patient = {
+        "fev1_fvc": 0.55,
+        "fev1_percent_predicted": 45,
+        "symptom_score": 3,
+        "exacerbations_last_year": 2,
+        "hospitalizations_last_year": 1,
+    }
+    result = diagnose(patient)
+    assert result["diagnosis"] is True
+    assert result["gold_stage"] == 3
+    assert result["risk_group"] == "D"
+
+
+def test_no_copd_diagnosis():
+    patient = {
+        "fev1_fvc": 0.8,
+        "fev1_percent_predicted": 90,
+        "symptom_score": 0,
+        "exacerbations_last_year": 0,
+        "hospitalizations_last_year": 0,
+    }
+    result = diagnose(patient)
+    assert result["diagnosis"] is False
+    assert result["gold_stage"] is None
+    assert result["risk_group"] is None
+


### PR DESCRIPTION
## Summary
- add `copd_analyzer` module with GOLD 2025 diagnosis and classification logic
- expose helper functions from `src` package
- provide unit tests for typical scenarios
- document module usage in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ade39e48c833187919c6530a76b47