### PR TITLE
Add COPD CLI, analysis module, and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # Prueba01
-aplicación para uso médico: analizar los datos del paciente aportados por el médico y primero definir si llena criterios para el diagnóstico de EPOC Enfermedad Pulmonar Obstructiva Crónica y segundo clasificarla. Debe usar los datos aportados por la "Guía de la iniciativa GOLD 2025.pdf" 
+
+Aplicación para uso médico que analiza los datos del paciente aportados por el clínico.
+Primero define si cumple criterios para el diagnóstico de EPOC (Enfermedad Pulmonar
+Obstructiva Crónica) y, en caso afirmativo, la clasifica según la guía GOLD 2025.
+
+## Requisitos
+
+Se requiere Python 3.8 o superior.
+
+## Uso
+
+El análisis puede ejecutarse desde la línea de comandos con el script `copd_cli.py`:
+
+```bash
+python copd_cli.py --fev1 1.2 --fvc 3.0 --fev1_percent 55
+```
+
+La salida muestra si el paciente tiene EPOC y su clasificación GOLD.
+
+## Referencia
+
+Los criterios usados se basan en la "Guía de la iniciativa GOLD 2025" incluida en este
+repositorio.
+

--- a/copd_analysis.py
+++ b/copd_analysis.py
@@ -1,0 +1,45 @@
+"""COPD analysis module.
+
+This module provides a function to determine COPD diagnosis and GOLD classification
+based on patient spirometry data.
+"""
+
+from typing import Dict
+
+
+def analyze_patient(fev1: float, fvc: float, fev1_percent: float) -> Dict[str, str]:
+    """Analyze patient data to diagnose COPD and classify its severity.
+
+    Parameters
+    ----------
+    fev1: float
+        Forced expiratory volume in the first second (liters).
+    fvc: float
+        Forced vital capacity (liters).
+    fev1_percent: float
+        FEV1 expressed as percent of the predicted value.
+
+    Returns
+    -------
+    Dict[str, str]
+        A dictionary with keys ``diagnosis`` and ``classification``.
+    """
+    ratio = fev1 / fvc
+    diagnosed = ratio < 0.70
+
+    if diagnosed:
+        if fev1_percent >= 80:
+            classification = "GOLD 1: Mild"
+        elif fev1_percent >= 50:
+            classification = "GOLD 2: Moderate"
+        elif fev1_percent >= 30:
+            classification = "GOLD 3: Severe"
+        else:
+            classification = "GOLD 4: Very Severe"
+        diagnosis = "COPD"
+    else:
+        classification = "Not Applicable"
+        diagnosis = "No COPD"
+
+    return {"diagnosis": diagnosis, "classification": classification}
+

--- a/copd_cli.py
+++ b/copd_cli.py
@@ -1,0 +1,29 @@
+"""Command-line interface for COPD analysis."""
+
+import argparse
+from copd_analysis import analyze_patient
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Analyze patient data for COPD")
+    parser.add_argument("--fev1", type=float, required=True, help="FEV1 in liters")
+    parser.add_argument("--fvc", type=float, required=True, help="FVC in liters")
+    parser.add_argument(
+        "--fev1_percent",
+        type=float,
+        required=True,
+        help="FEV1 expressed as percent of predicted value",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    result = analyze_patient(args.fev1, args.fvc, args.fev1_percent)
+    print(f"Diagnosis: {result['diagnosis']}")
+    print(f"Classification: {result['classification']}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_copd_analysis.py
+++ b/tests/test_copd_analysis.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from copd_analysis import analyze_patient
+
+
+def test_diagnosis_positive():
+    result = analyze_patient(1.0, 2.0, 45)
+    assert result["diagnosis"] == "COPD"
+    assert result["classification"] == "GOLD 3: Severe"
+
+
+def test_diagnosis_negative():
+    result = analyze_patient(3.0, 3.0, 90)
+    assert result["diagnosis"] == "No COPD"
+    assert result["classification"] == "Not Applicable"


### PR DESCRIPTION
## Summary
- implement COPD analysis module
- add command-line interface script
- document usage in README
- include unit tests for COPD analysis
- add `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ade3af1bc8331aa2fa9838c4c3c61