### PR TITLE
Add patient CSV loader and tests

### DIFF
--- a/data_models.py
+++ b/data_models.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Patient:
+    id: int
+    name: str
+    age: int

--- a/patient_loader.py
+++ b/patient_loader.py
@@ -1,0 +1,8 @@
+import pandas as pd
+from data_models import Patient
+
+
+def load_from_csv(path: str) -> list[Patient]:
+    """Load patient records from a CSV file."""
+    df = pd.read_csv(path)
+    return [Patient(**row.to_dict()) for _, row in df.iterrows()]

--- a/tests/test_patient_loader.py
+++ b/tests/test_patient_loader.py
@@ -1,0 +1,18 @@
+import pandas as pd
+from patient_loader import load_from_csv
+from data_models import Patient
+
+
+def test_load_from_csv(tmp_path):
+    csv_file = tmp_path / 'patients.csv'
+    df = pd.DataFrame([
+        {'id': 1, 'name': 'Alice', 'age': 30},
+        {'id': 2, 'name': 'Bob', 'age': 40},
+    ])
+    df.to_csv(csv_file, index=False)
+
+    patients = load_from_csv(str(csv_file))
+    assert patients == [
+        Patient(id=1, name='Alice', age=30),
+        Patient(id=2, name='Bob', age=40),
+    ]


### PR DESCRIPTION
## Summary
- implement `load_from_csv` for `Patient` dataclass
- add simple dataclass model
- add tests for CSV loader

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686ad5e328b08331905b9c7eb90dfc2e